### PR TITLE
Remove plants#5

### DIFF
--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -17,6 +17,14 @@ class PlantsController < ApplicationController
     end
   end
   
+  def destroy
+    plant = Plant.find(params[:id])
+    garden = plant.garden
+    plant.destroy
+    flash[:success] = 'Goodbye dear plant'
+    redirect_to garden_path(garden)
+  end
+  
   private
   
   def plant_params

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -7,7 +7,7 @@
         <li>
           <%= plant.name %><br />
           Watering Requirements: <%= plant.times_per_week.round(0) %> times/week<br />
-          <%= button_to 'Remove Plant', plant_path(plant), method: :delete %>
+          <%= button_to 'Remove Plant', plant_path(plant), method: :delete, data: {confirm: "Are you sure?"} %>
         </li>
       </div>
     <% end %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -3,8 +3,13 @@
 <div class="plants">
   <ul>
     <% @garden.plants.each do |plant| %>
-      <li><%= plant.name %><br />
-      Watering Requirements: <%= plant.times_per_week.round(0) %> times/week</li>
+      <div id="plant-<%= plant.id %>"
+        <li>
+          <%= plant.name %><br />
+          Watering Requirements: <%= plant.times_per_week.round(0) %> times/week<br />
+          <%= button_to 'Remove Plant', plant_path(plant), method: :delete %>
+        </li>
+      </div>
     <% end %>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
 
   get '/dashboard', to: "users#show"
   resources :gardens, only: [:new, :create, :show], shallow: true do
-    resources :plants, only: [:new, :create]
+    resources :plants, only: [:new, :create, :destroy]
   end
 end

--- a/spec/factories/gardens.rb
+++ b/spec/factories/gardens.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :garden do
     zip_code { "MyString" }
-    name { "MyString" }
-    user { nil }
+    sequence(:name) { |n| "Garden #{n}" }
+    user
   end
 end

--- a/spec/factories/plants.rb
+++ b/spec/factories/plants.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :plant do
-    name { "MyString" }
-    times_per_week { 1.5 }
-    garden { nil }
+    sequence(:name) { |n| "Plant #{n}" }
+    sequence(:times_per_week) { |n| n }
+    garden
   end
 end

--- a/spec/features/user_can_delete_plants_spec.rb
+++ b/spec/features/user_can_delete_plants_spec.rb
@@ -23,7 +23,3 @@ describe 'As a user logged in to the site' do
     end
   end
 end
-
-# From my garden's show page, I have the ability to delete my plant. 
-# When I select the delete button, I am returned to my garden's show page, and I no longer see that plant. 
-# I see a flash message saying "goodbye dear plant"

--- a/spec/features/user_can_delete_plants_spec.rb
+++ b/spec/features/user_can_delete_plants_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'As a user logged in to the site' do
+  describe 'on a garden show page' do
+    it 'can delete a plant' do
+      garden = create(:garden)
+      plant_1 = create(:plant, garden: garden)
+      plant_2 = create(:plant, garden: garden)
+      
+      visit garden_path(garden)
+      
+      expect(page).to have_content(plant_1.name)
+      expect(page).to have_content(plant_2.name)
+      
+      within("#plant-#{plant_1.id}") do
+        click_on 'Remove Plant'
+      end
+      
+      expect(current_path).to eq(garden_path(garden))
+      expect(page).to have_content('Goodbye dear plant')
+      expect(page).to_not have_content(plant_1.name)
+      expect(page).to have_content(plant_2.name)
+    end
+  end
+end
+
+# From my garden's show page, I have the ability to delete my plant. 
+# When I select the delete button, I am returned to my garden's show page, and I no longer see that plant. 
+# I see a flash message saying "goodbye dear plant"


### PR DESCRIPTION
User Story 5: Remove Plants
Adds ability for user to delete plants:
- Adds 'Remove Plant' button to garden show page
- Adds route and controller method for plant destroy
- Adds flash message for success
- Updates factories for plants and gardens so the names increment
- All tests passing
Closes #5 