### PR TITLE
Switches to using google uid to identify users#55

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,15 +3,15 @@ class User < ApplicationRecord
   validates_presence_of :first_name,
                         :email,
                         :google_token,
-                        :google_id_token
+                        :google_id
 
   def self.from_google_auth(auth_info)
-    where(google_id_token: auth_info[:extra][:id_token]).first_or_create do |new_user|
+    where(google_id: auth_info[:info][:id]).first_or_create do |new_user|
       new_user[:google_token]         = auth_info[:credentials][:token]
       new_user[:first_name]            = auth_info[:info][:first_name]
       new_user[:last_name]              = auth_info[:info][:last_name]
       new_user[:email]                 = auth_info[:info][:email]
-      new_user[:google_id_token]        = auth_info[:extra][:id_token]
+      new_user[:google_id]            = auth_info[:uid]
     end
   end
 end

--- a/db/migrate/20190212173327_create_users.rb
+++ b/db/migrate/20190212173327_create_users.rb
@@ -5,7 +5,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
       t.string :last_name
       t.string :email
       t.string :google_token
-      t.string :google_id
+      t.string :google_id_token
 
       t.timestamps
     end

--- a/db/migrate/20190212173327_create_users.rb
+++ b/db/migrate/20190212173327_create_users.rb
@@ -5,7 +5,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
       t.string :last_name
       t.string :email
       t.string :google_token
-      t.string :google_id_token
+      t.string :google_id
 
       t.timestamps
     end

--- a/db/migrate/20190217024426_change_user_google_id_token_to_google_id.rb
+++ b/db/migrate/20190217024426_change_user_google_id_token_to_google_id.rb
@@ -1,0 +1,5 @@
+class ChangeUserGoogleIdTokenToGoogleId < ActiveRecord::Migration[5.1]
+  def change
+    rename_column(:users, :google_id, :google_id)
+  end
+end

--- a/db/migrate/20190217024426_change_user_google_id_token_to_google_id.rb
+++ b/db/migrate/20190217024426_change_user_google_id_token_to_google_id.rb
@@ -1,5 +1,5 @@
 class ChangeUserGoogleIdTokenToGoogleId < ActiveRecord::Migration[5.1]
   def change
-    rename_column(:users, :google_id, :google_id)
+    rename_column(:users, :google_id_token, :google_id)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190215032805) do
+ActiveRecord::Schema.define(version: 20190217024426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20190215032805) do
     t.string "last_name"
     t.string "email"
     t.string "google_token"
-    t.string "google_id_token"
+    t.string "google_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     last_name { "MyString" }
     email { "MyString" }
     google_token { "MyString" }
-    google_id_token { "MyString" }
+    google_id { "MyString" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe User, type: :model do
     it { should validate_presence_of :first_name }
     it { should validate_presence_of :email }
     it { should validate_presence_of :google_token }
-    it { should validate_presence_of :google_id_token }
+    it { should validate_presence_of :google_id }
   end
 
   describe 'Relationships' do


### PR DESCRIPTION
Storing the uid from google allows the user to persist across sections. I'm about 99.9% sure this is not a security issue, but that the unclear wording of the warning on google developer site (https://developers.google.com/identity/sign-in/web/backend-auth) mislead us, along with our incomplete understanding of everything that omni_auth was doing for is.

https://stackoverflow.com/questions/8311836/how-to-identify-a-google-oauth2-user
https://stackoverflow.com/questions/46947615/how-to-securely-insert-and-user-user-info-in-databases-when-using-google-sign-in
https://developers.google.com/identity/sign-in/web/reference

closes #55
