### PR TITLE
App Speed Analytics - Analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'omniauth-google-oauth2'
 gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
 gem 'yarn'
+gem 'newrelic_rpm'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    newrelic_rpm (6.0.0.351)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -272,6 +273,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (>= 3.0.5, < 3.2)
+  newrelic_rpm
   omniauth-google-oauth2
   pg (>= 0.18, < 2.0)
   pry

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,45 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated February 17, 2019
+#
+# This configuration file is custom generated for Turing School_27
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: d50d24d71826af76edcd0a00a7438dc667174e12
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: My Application
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: My Application (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: My Application (Staging)
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
Because we utilize a log-in to get to the site, the simple, free versions of speed analyzers only work for our welcome page. Therefore to get analytics it is necessary to integrate one of the analytics sites into the app (and deploy the app with it). 
Setup included:
- Signing up on NewRelic
- Adding a gem to the gem file
- Running bundle
- Adding a downloaded yml file to the config directory in the app.

https://rpm.newrelic.com