### PR TITLE
Handling failed api#90

### DIFF
--- a/app/facades/dashboard_facade.rb
+++ b/app/facades/dashboard_facade.rb
@@ -6,4 +6,8 @@ class DashboardFacade
   def weather(lat, long)
     @_weather ||= Weather.new(lat, long)
   end
+  
+  def has_weather?(garden)
+    garden.lat && garden.long && weather(garden.lat, garden.long).weather_info
+  end
 end

--- a/app/facades/garden_facade.rb
+++ b/app/facades/garden_facade.rb
@@ -6,4 +6,8 @@ class GardenFacade
   def weather(lat, long)
     @_weather ||= Weather.new(lat, long)
   end
+  
+  def has_weather?(garden)
+    garden.lat && garden.long && weather(garden.lat, garden.long).weather_info
+  end
 end

--- a/app/models/weather.rb
+++ b/app/models/weather.rb
@@ -6,10 +6,8 @@ attr_reader :lat, :long
   end
 
   def chance_of_rain(day_index)
-    if weather_info
-      raw_day = weather_info[:daily][:data][day_index]
-      raw_day[:precipProbability] * 100
-    end
+    raw_day = weather_info[:daily][:data][day_index]
+    raw_day[:precipProbability] * 100
   end
 
   def weather_info

--- a/app/models/weather.rb
+++ b/app/models/weather.rb
@@ -6,8 +6,10 @@ attr_reader :lat, :long
   end
 
   def chance_of_rain(day_index)
-    raw_day = weather_info[:daily][:data][day_index]
-    raw_day[:precipProbability] * 100
+    if weather_info
+      raw_day = weather_info[:daily][:data][day_index]
+      raw_day[:precipProbability] * 100
+    end
   end
 
   def weather_info

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -36,7 +36,7 @@
           </div>
         <% end %>
       </ul>
-      <% if garden.lat && garden.long %>
+      <% if @facade.has_weather?(garden) %>
         <h3>Weather in <%= garden.name %>:</h3>
         <% @next_seven_days.each_with_index do |date, index| %>
           <h5 class="weather_day"><%= date %>, Chance of Rain: <%= @facade.weather(garden.lat, garden.long).chance_of_rain(index) %>%</h5>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
     <% @user.gardens.each do |garden| %>
       <div class="card">
         <div id="garden-<%= garden.id %>">
-          <% if garden.lat && garden.long %>
+          <% if @facade.has_weather?(garden) %>
             <h3>Weather in <%= link_to garden.name, garden_path(garden) %> (<%= garden.zip_code %>):</h3>
             <br>
             <% @next_seven_days.each_with_index do |date, index| %>

--- a/spec/features/users/user_can_still_see_pages_if_api_calls_fail_spec.rb
+++ b/spec/features/users/user_can_still_see_pages_if_api_calls_fail_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe 'As a logged in user of the site' do
+  describe 'on the dashboard' do
+    it 'can see the site even if API calls fail' do
+      user = create(:user)
+      garden = create(:garden, user: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      allow_any_instance_of(DarkSkyService).to receive(:get_weather).and_return(nil)
+      
+      visit dashboard_path
+      
+      expect(page).to_not have_content('Weather')
+      expect(page).to_not have_css('weather_day')
+      expect(page).to have_content(garden.name)
+    end
+  end
+end

--- a/spec/features/users/user_can_still_see_pages_if_api_calls_fail_spec.rb
+++ b/spec/features/users/user_can_still_see_pages_if_api_calls_fail_spec.rb
@@ -16,4 +16,20 @@ describe 'As a logged in user of the site' do
       expect(page).to have_content('Garden Dashboard')
     end
   end
+  
+  describe 'on the gardens index page' do
+    it 'can see the site even if API calls fail' do
+      user = create(:user)
+      garden = create(:garden, user: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      allow_any_instance_of(DarkSkyService).to receive(:get_weather).and_return(nil)
+      
+      visit gardens_path
+      
+      expect(page.status_code).to eq(200)
+      expect(page).to_not have_content('Weather')
+      expect(page).to_not have_css('weather_day')
+      expect(page).to have_content(garden.name)
+    end
+  end
 end

--- a/spec/features/users/user_can_still_see_pages_if_api_calls_fail_spec.rb
+++ b/spec/features/users/user_can_still_see_pages_if_api_calls_fail_spec.rb
@@ -10,9 +10,10 @@ describe 'As a logged in user of the site' do
       
       visit dashboard_path
       
+      expect(page.status_code).to eq(200)
       expect(page).to_not have_content('Weather')
       expect(page).to_not have_css('weather_day')
-      expect(page).to have_content(garden.name)
+      expect(page).to have_content('Garden Dashboard')
     end
   end
 end


### PR DESCRIPTION
We want to make sure the page loads don't fail even if the weather API call does fail. 
- Adds logic to Dashboard page to check that we have weather data before trying to display it
- Adds `has_weather?` method to DashboardFacade
- Adds logic to Garden Index page to check that we have weather data before trying to display it
- Adds `has_weather?` method to GardenFacade. 
- All tests passing
Please let me know if there are other spots that you can think of that I should check! @bendelonlee 
 do you remember the page that you were on that prompted this card? 
This is something we should keep in mind if we add weather data/other API data to other pages. 
Closes #90