### PR TITLE
Dry

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -11,7 +11,7 @@ $( document ).ready(function() {
       $(`#watering-${id}-name`).toggleClass("watered-plant-name");
       $(`#update-watering-${id}`).click();
     });
-    
+
     $( ".draggable" ).draggable({
       helper:"clone",
       containment:"document"
@@ -20,8 +20,9 @@ $( document ).ready(function() {
     $( ".droppable" ).droppable({
       tolerance: 'touch',
       drop: function( event, ui ) {
+        debugger;
         ui.draggable.detach().appendTo(this);
-        
+        $(this).find(".no-waterings").hide();
         let id = ui.draggable[0].id
         let field = `#${id}-water-time`
         let date = this.parentElement.attributes.name.nodeValue

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -42,6 +42,10 @@ class Day
             .where(plant: { garden: { user_gardens: {user: @user} } } )
   end
 
+  def waterings?
+    waterings.any?
+  end
+
   def check_box_type
     if @date.day == Time.now.day
       "enabled-checkbox"

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -4,13 +4,10 @@
         <div class="<%= day.css_classes %>" name='<%= day.css_name %>'  id='<%= day.css_id %>'>
           <h3><%= day.day_of_week_name %></h3>
           <h6><%= day.small_date %></h6>
-          <% if day.waterings? %>
-            <div class="droppable">
-              <%= render partial: "checkboxes", locals: {day: day} %>
-            </div>
-          <% else %>
-            <p>No waterings scheduled today.</p>
-          <% end %>
+          <div class="droppable">
+            <%= render partial: "checkboxes", locals: {day: day} %>
+            <p <%= day.waterings? ? "hidden=true" : "" %> class="no-waterings">No waterings scheduled today.</p>
+          </div>
         </div>
       <hr>
       <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -4,9 +4,13 @@
         <div class="<%= day.css_classes %>" name='<%= day.css_name %>'  id='<%= day.css_id %>'>
           <h3><%= day.day_of_week_name %></h3>
           <h6><%= day.small_date %></h6>
-          <div class="droppable">
-            <%= render partial: "checkboxes", locals: {day: day} %>
-          </div>
+          <% if day.waterings? %>
+            <div class="droppable">
+              <%= render partial: "checkboxes", locals: {day: day} %>
+            </div>
+          <% else %>
+            <p>No waterings scheduled today.</p>
+          <% end %>
         </div>
       <hr>
       <% end %>

--- a/spec/features/users/user_sees_schedule_spec.rb
+++ b/spec/features/users/user_sees_schedule_spec.rb
@@ -88,6 +88,11 @@ describe 'user sees schedule' do
         expect(page).to have_content(@watering_1.plant.name)
       end
     end
-
+    scenario 'when there are no waterings on a particular day, I see a message' do
+      yesterday = Time.now.to_date - 1.days
+      within("[name=#{yesterday.strftime('%b%d')}]") do
+        expect(page).to have_content("No waterings scheduled today.")
+      end
+    end
   end
 end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -53,4 +53,16 @@ describe Day do
     day = Day.new(Time.now.to_date, watering.plant.garden.users.first)
     expect(day.waterings.first).to eq(watering)
   end
+
+  it ".waterings?" do
+    plant_1 = create(:plant, times_per_week: 7)
+    watering = plant_1.reload.waterings.first
+    day_1 = Day.new(Time.now.to_date, watering.plant_1.garden.users.first)
+    expect(day_1.waterings?).to eq(true)
+
+    plant_2 = create(:plant, times_per_week: 2)
+    watering = plant_2.reload.waterings.first
+    day_2 = Day.new(Time.now.to_date, watering.plant_2.garden.users.first)
+    expect(day_2.waterings?).to eq(false)
+  end
 end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -57,12 +57,12 @@ describe Day do
   it ".waterings?" do
     plant_1 = create(:plant, times_per_week: 7)
     watering = plant_1.reload.waterings.first
-    day_1 = Day.new(Time.now.to_date, watering.plant_1.garden.users.first)
+    day_1 = Day.new(Time.now.to_date, watering.plant.garden.users.first)
     expect(day_1.waterings?).to eq(true)
 
     plant_2 = create(:plant, times_per_week: 2)
     watering = plant_2.reload.waterings.first
-    day_2 = Day.new(Time.now.to_date, watering.plant_2.garden.users.first)
+    day_2 = Day.new(Time.now.to_date, watering.plant.garden.users.first)
     expect(day_2.waterings?).to eq(false)
   end
 end


### PR DESCRIPTION
Adds message of "No waterings scheduled today" for days where no waterings are scheduled.  Includes new `waterings?` method.  Allows draggable and droppable functionality for assigned waterings.  All tests passing.  Driver-nav with @bendelonlee 