### PR TITLE
Links

### DIFF
--- a/app/controllers/caretaker/start_controller.rb
+++ b/app/controllers/caretaker/start_controller.rb
@@ -3,7 +3,7 @@ class Caretaker::StartController < ApplicationController
   def new
     garden_id = params[:garden_id]
     UserGarden.create(user: current_user, garden_id: garden_id, relationship_type: 1)
-    flash[:notice] = "Welcome to your friend's garden!"
+    flash[:success] = "Welcome to your friend's garden!"
     redirect_to garden_path(garden_id)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       redirect_to admin_dashboard_path
     else
       session[:user_id] = user.id
-      flash[:success] = "Welcome, gardener, we're glad to have you among the roses."
+      flash[:success] = "Welcome, gardener; water you waiting for!?"
       redirect_to dashboard_path
     end
   end

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -20,6 +20,11 @@
         <%= link_to 'Update Garden Information', edit_garden_path(@garden), class: "btn" %>
       </button>
     </div>
+    <div class="btn-group mr-2" role="group" aria-label="Fourth group">
+      <button type="button" class="btn btn-secondary" id="schedule-button">
+        <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
+      </button>
+    </div>
     <br>
   </div>
 </section>

--- a/app/views/schedules/_checkboxes.html.erb
+++ b/app/views/schedules/_checkboxes.html.erb
@@ -5,7 +5,7 @@
         <%= image_tag(asset_path("icons/brown-checkmark.png"), class: watering.plant_image_css_class) %>
       <% end %>
       <%= tag.span(id: "watering-#{watering.id}-name", class: watering.plant_name_css_class) do %>
-        <%= watering.plant.name %>
+        <%= link_to "#{watering.plant.name}", plant_path(watering.plant) %>
       <% end %>
       <%= f.text_field(:completed, hidden: true, id: "watering-#{watering.id}-completed") %>
       <%= f.text_field(:water_time, hidden: true, id: "watering-#{watering.id}-water-time") %>

--- a/spec/features/users/user_sees_garden_show_page_spec.rb
+++ b/spec/features/users/user_sees_garden_show_page_spec.rb
@@ -24,7 +24,14 @@ describe 'as a logged in user' do
         end
         expect(page).to have_content("Watering Requirements: #{plant_2.times_per_week.round(1)} times/week")
       end
+      expect(page).to have_link("Add a Plant to Your Garden!")
+      expect(page).to have_button("Delete Garden")
+      expect(page).to have_link("Update Garden Information")
 
+      within "#schedule-button" do
+        click_on "Watering Schedule"
+      end
+      expect(current_path).to eq(schedules_path)
     end
 
     it 'only shows information about their garden' do

--- a/spec/features/users/user_sees_schedule_spec.rb
+++ b/spec/features/users/user_sees_schedule_spec.rb
@@ -18,13 +18,19 @@ describe 'user sees schedule' do
     click_link "View Watering Schedule"
     watering = waterings.first
 
+    expect(page).to have_content(plant_2.name, count: 1)
+    expect(page).to have_content(watering.plant.name, count: 2)
+
     within("div[name='#{watering.water_time.strftime('%b%d')}']") do
       expect(page).to have_content(watering.water_time.strftime('%A'))
       expect(page).to have_content(watering.water_time.strftime('%b. %d'))
-      expect(page).to have_content(plant.name, count: 2)
+      expect(page).to have_link(plant.name, count: 2)
+
+      within "#watering-#{plant.waterings.first.id}-name" do
+        click_link(plant.name)
+      end
+      expect(current_path).to eq(plant_path(plant))
     end
-    expect(page).to have_content(plant_2.name, count: 1)
-    expect(page).to have_content(watering.plant.name, count: 2)
   end
 
   describe "changes are saved" do

--- a/spec/features/visitors/visitor_signs_in_with_google_spec.rb
+++ b/spec/features/visitors/visitor_signs_in_with_google_spec.rb
@@ -8,6 +8,6 @@ describe 'as a visitor' do
     expect(page).to have_link("Sign in with Google")
 
     click_link "Sign in with Google"
-    expect(page).to have_content("Welcome, gardener, we're glad to have you among the roses.")
+    expect(page).to have_content("Welcome, gardener; water you waiting for!?")
   end
 end


### PR DESCRIPTION
Adds links to schedule view page from the garden show.  Makes all plant names links to their respective show pages from the schedule.  Updates flash message for adding a caretaker to be a success type for styling purposes.  All tests passing.