### PR TITLE
Schedule text

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require_relative 'config/application'
 Rails.application.load_tasks
 task :rainy_day_texts => :environment do
   num_texts = RainyDayJob.set.perform_now
-  puts "#{num_texts}texts sent"
+  puts "#{num_texts} texts sent"
 end
 
 task get_weather_data: :environment do

--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,9 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-task :rainy_day => :environment do
-  RainyDayJob.set.perform_now(:just_set_up)
-  puts "let the texting begin"
+task :rainy_day_texts => :environment do
+  num_texts = RainyDayJob.set.perform_now
+  puts "#{num_texts}texts sent"
 end
 
 task get_weather_data: :environment do

--- a/app/jobs/rainy_day_job.rb
+++ b/app/jobs/rainy_day_job.rb
@@ -15,18 +15,6 @@ class RainyDayJob < ApplicationJob
     @num_texts
   end
 
-  def early_next_morning
-    self.class.early_next_morning
-  end
-
-  def self.early_next_morning
-    Time.use_zone("Mountain Time (US & Canada)") { 1.day.from_now.beginning_of_day + 5.hours }
-  end
-
-  def users_with_phone_numbers
-    User.where.not(telephone: nil)
-  end
-
   def send_rainy_day_texts(rainy_day)
     rainy_day.gardens.each do |garden|
       garden.users.each do |user|

--- a/app/jobs/rainy_day_job.rb
+++ b/app/jobs/rainy_day_job.rb
@@ -17,7 +17,7 @@ class RainyDayJob < ApplicationJob
 
   def send_rainy_day_texts(rainy_day)
     rainy_day.gardens.each do |garden|
-      garden.users.each do |user|
+      garden.users.where.not(telephone: nil).each do |user|
         @num_texts += 1
         RainyDayTexter.send_rainy_day_text(user, garden, rainy_day.chance_of_rain)
       end

--- a/app/models/rainy_day.rb
+++ b/app/models/rainy_day.rb
@@ -11,7 +11,7 @@ class RainyDay
 
   def self.generate_rainy_days
     gardens_to_check_weather_for.map do | garden |
-      weather = Weather.new(garden)
+      weather = Weather.new(garden)      
       if (chance = weather.chance_of_rain(0)) > 50
         RainyDay.new(chance_of_rain: chance, zip_code: garden.zip_code)
       end

--- a/app/texters/rainy_day_texter.rb
+++ b/app/texters/rainy_day_texter.rb
@@ -1,7 +1,7 @@
 class RainyDayTexter < ApplicationTexter
 
-  def self.send_rainy_day_text(garden, chance)
-    MyTwillioClient.api.account.messages.create(rainy_day_text(garden, chance))
+  def self.send_rainy_day_text(user, garden, chance)
+    MyTwillioClient.api.account.messages.create(rainy_day_text(user, garden, chance))
   end
 
   def self.send_admin_text(scheduled_time)
@@ -10,12 +10,12 @@ class RainyDayTexter < ApplicationTexter
 
   private
 
-  def self.rainy_day_text(garden, chance)
-
+  def self.rainy_day_text(user, garden, chance)
+    attribution = user.own_gardens.include?(garden) ? "your garden" : "#{user.first_name}'s garden"
     {
       from: TwillioAccountPhoneNumber,
-      to: "+1#{garden.users.first.telephone}",
-      body: "Heads up from Thirsty Plants! There is a #{chance}% chance of precipitation today in your garden #{garden.name} at #{garden.zip_code}."
+      to: "+1#{user.telephone}",
+      body: "Heads up from Thirsty Plants! There is a #{chance}% chance of precipitation today in #{attribution} #{garden.name} at #{garden.zip_code}."
     }
   end
 

--- a/app/texters/rainy_day_texter.rb
+++ b/app/texters/rainy_day_texter.rb
@@ -4,10 +4,6 @@ class RainyDayTexter < ApplicationTexter
     MyTwillioClient.api.account.messages.create(rainy_day_text(user, garden, chance))
   end
 
-  def self.send_admin_text(scheduled_time)
-    MyTwillioClient.api.account.messages.create(admin_text(scheduled_time))
-  end
-
   private
 
   def self.rainy_day_text(user, garden, chance)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  config.action_mailer.default_url_options = { :host => 'https://thirsty-plants.herokuapp.com/' }
+  config.action_mailer.default_url_options = { :host => 'https://thirsty-plants.herokuapp.com' }
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/jobs/rainy_day_job_spec.rb
+++ b/spec/jobs/rainy_day_job_spec.rb
@@ -21,13 +21,6 @@ RSpec.describe RainyDayJob, type: :job do
     }.to have_enqueued_job(RainyDayJob)
   end
 
-  it 'reschedules itself for the next morning' do
-    stub_twillio
-    expect {
-      RainyDayJob.perform_now
-    }.to have_enqueued_job(RainyDayJob).at(RainyDayJob.early_next_morning)
-  end
-
   it 'sends texts' do
     def weather_service_stub(chance)
       {
@@ -52,9 +45,9 @@ RSpec.describe RainyDayJob, type: :job do
     allow_any_instance_of(DarkSkyService).to receive(:get_weather).with(@garden_2.lat, @garden_2.long).and_return(weather_service_stub(0.3))
     allow_any_instance_of(DarkSkyService).to receive(:get_weather).with(@garden_3.lat, @garden_3.long).and_return(weather_service_stub(0.3))
 
-    allow(RainyDayTexter).to receive(:send_rainy_day_text).with(@garden_1, 80.0) {}
+    allow(RainyDayTexter).to receive(:send_rainy_day_text).with(@garden_1.users.first, @garden_1, 80.0) {}
     RainyDayJob.new.send(:text_users)
-    expect(RainyDayTexter).to have_received(:send_rainy_day_text).with(@garden_1, 80.0)
+    expect(RainyDayTexter).to have_received(:send_rainy_day_text).with(@garden_1.users.first, @garden_1, 80.0)
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ VCR.configure do |config|
   config.filter_sensitive_data('<google2>') { ENV['GOOGLE_SECRET']}
   config.filter_sensitive_data('<twilliotok>') { ENV['TWILLIO_AUTH_TOKEN']}
   config.filter_sensitive_data('<twillioid>') { ENV['TWILLIO_ACCOUNT_SID']}
+  config.filter_sensitive_data('<twillioid>') { ENV['ADMIN_PHONE_NUMBER']}
 end
 
 def stub_omniauth

--- a/spec/texters/rainy_day_texter_spec.rb
+++ b/spec/texters/rainy_day_texter_spec.rb
@@ -11,7 +11,7 @@ describe RainyDayTexter do
         to: "+1#{garden.users.first.telephone}",
         body: "Heads up from Thirsty Plants! There is a #{chance}% chance of precipitation today in your garden #{garden.name} at #{garden.zip_code}."
       }
-      expect(RainyDayTexter.rainy_day_text(garden, chance)).to eq(expected_text)
+      expect(RainyDayTexter.rainy_day_text(garden.users.first, garden, chance)).to eq(expected_text)
     end
 
     it 'admin_text' do


### PR DESCRIPTION
The Heroku Scheduler will now call the RainyDayJob.perform_now every morning at 8AM rather than the job scheduling a new job after it's complete.
Rather than only the first user receiving a text, all of a garden's users receive texts, and the message indicates whether it is their garden or their friend's garden.
Hopefully fixes link error in email in production by removing a backslash.