### PR TITLE
Caretakers can cannot#166

### DIFF
--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -1,5 +1,6 @@
 class GardensController < ApplicationController
-
+  before_action :require_garden_owner, only: [:edit, :update, :destroy]
+  
   def new
     @garden = Garden.new
     3.times { @garden.plants.build }
@@ -18,8 +19,7 @@ class GardensController < ApplicationController
   end
 
   def show
-    @garden = Garden.find(params[:id])
-    unless @garden.users.include? current_user
+    unless garden.users.include? current_user
       render_404
     end
   end
@@ -31,29 +31,32 @@ class GardensController < ApplicationController
   end
 
   def edit
-    @garden = Garden.find(params[:id])
+    @garden = garden
   end
 
   def update
-    @garden = Garden.find(params[:id])
-    @garden.update(garden_params)
-    if @garden.save
+    garden.update(garden_params)
+    if garden.save
       flash[:success] = 'Garden updated successfully!'
-      redirect_to garden_path(@garden)
+      redirect_to garden_path(garden)
     else
-      @errors = @garden.errors
+      @errors = garden.errors
       render :edit
     end
   end
 
   def destroy
-    garden = Garden.find(params[:id])
     garden.destroy
     flash[:success] = "Garden successfully deleted."
     redirect_to dashboard_path
   end
 
   private
+  
+  def garden
+    @garden ||= Garden.find(params[:id])
+  end
+  
   def garden_params
     params.require(:garden)
     .permit(:name, :zip_code, :plants,
@@ -69,5 +72,8 @@ class GardensController < ApplicationController
     end
     days
   end
-
+  
+  def require_garden_owner
+    render_404 unless current_user.own_gardens.include?(garden)
+  end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,4 +1,5 @@
 class PlantsController < ApplicationController
+  before_action :require_garden_owner, only: [:edit, :update, :destroy]
 
   def new
     @garden = Garden.find(params[:garden_id])
@@ -18,24 +19,23 @@ class PlantsController < ApplicationController
   end
 
   def edit
-    @plant = Plant.find(params[:id])
+    @plant = plant
   end
 
   def update
-    @plant = Plant.find(params[:id])
-    @plant.update(plant_params)
-    if @plant.save
+    plant.update(plant_params)
+    if plant.save
       flash[:success] = 'Plant updated successfully!'
-      @plant.generate_waterings  
-      redirect_to garden_path(@plant.garden)
+      plant.generate_waterings  
+      redirect_to garden_path(plant.garden)
     else
-      @errors = @plant.errors
+      @errors = plant.errors
       render :edit
     end
   end
 
   def show
-    @plant = Plant.find(params[:id])
+    @plant = plant
   end
 
   def destroy
@@ -47,8 +47,16 @@ class PlantsController < ApplicationController
   end
 
   private
+  
+  def plant
+    @plant ||= Plant.find(params[:id])
+  end
 
   def plant_params
     params.require(:plant).permit(:name, :times_per_week, :thumbnail)
+  end
+  
+  def require_garden_owner
+    render_404 unless current_user.own_gardens.include?(plant.garden)
   end
 end

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -40,7 +40,6 @@
                 </div>
               </div>
             </div>
-          </div>
           <% if @facade.has_weather?(garden) %>
             <div class="card">
               <div class="weather-card-<%= garden.id %>">
@@ -55,6 +54,7 @@
             <% end %>
           </div>
         </div>
+      </div>
       <% end %>
     </section>
   <% else %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -3,26 +3,28 @@
   <p>Located in <%= @garden.zip_code %></p>
 </div>
 
-<section class="garden-links">
-  <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-    <div class="btn-group mr-2" role="group" aria-label="First group">
-      <button type="button" class="btn btn-secondary" id="new-plant-button">
-        <%= link_to 'Add a Plant to Your Garden!', new_garden_plant_path(@garden), class: "btn" %>
-      </button>
+<% if current_user.own_gardens.include?(@garden) %>
+  <section class="garden-links">
+    <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+      <div class="btn-group mr-2" role="group" aria-label="First group">
+        <button type="button" class="btn btn-secondary" id="new-plant-button">
+          <%= link_to 'Add a Plant to Your Garden!', new_garden_plant_path(@garden), class: "btn" %>
+        </button>
+      </div>
+      <div class="btn-group mr-2" role="group" aria-label="Second group">
+        <button type="button" class="btn btn-secondary">
+          <%= button_to 'Delete Garden', garden_path(@garden), method: :delete, data: {confirm: "Are you sure?"}, class: "btn" %>
+        </button>
+      </div>
+      <div class="btn-group mr-2" role="group" aria-label="Third group">
+        <button type="button" class="btn btn-secondary" id="update-button">
+          <%= link_to 'Update Garden Information', edit_garden_path(@garden), class: "btn" %>
+        </button>
+      </div>
+      <br>
     </div>
-    <div class="btn-group mr-2" role="group" aria-label="Second group">
-      <button type="button" class="btn btn-secondary">
-        <%= button_to 'Delete Garden', garden_path(@garden), method: :delete, data: {confirm: "Are you sure?"}, class: "btn" %>
-      </button>
-    </div>
-    <div class="btn-group mr-2" role="group" aria-label="Third group">
-      <button type="button" class="btn btn-secondary" id="update-button">
-        <%= link_to 'Update Garden Information', edit_garden_path(@garden), class: "btn" %>
-      </button>
-    </div>
-    <br>
-  </div>
-</section>
+  </section>
+<% end %>
 
 <section class="plants-container">
   <% @garden.plants.each do |plant| %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -21,13 +21,13 @@
           <%= link_to 'Update Garden Information', edit_garden_path(@garden), class: "btn" %>
         </button>
       </div>
-      <br>
+      <div class="btn-group mr-2" role="group" aria-label="Fourth group">
+        <button type="button" class="btn btn-secondary" id="schedule-button">
+          <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
+        </button>
+      </div>
     </div>
-    <div class="btn-group mr-2" role="group" aria-label="Fourth group">
-      <button type="button" class="btn btn-secondary" id="schedule-button">
-        <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
-      </button>
-    </div>
+    <br>
     <br>
 </section>
 <% end %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -36,6 +36,7 @@
           <div class="user-img">
           <%= image_tag plant.thumbnail.url(:thumb) %>
           </div>
+        <% if current_user.own_gardens.include?(plant.garden)%>  
         <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
           <div class="btn-group mr-2" role="group" aria-label="First group">
             <button type="button" class="btn btn-secondary" id="remove-button">
@@ -46,6 +47,7 @@
             </button>
           </div>
         </div>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="icon" type="image/png" href="/favicon.png">
-    <link rel="shortcut icon" href="/favicon.png" type="image/png">
     <title>Thirsty Plants</title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag    'application', media: 'all' %>

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -13,4 +13,28 @@ describe 'As a caretaker of a garden' do
     
     expect(page).to_not have_button('Delete Garden')
   end
+  it 'cannot update that garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    
+    visit garden_path(garden)
+    
+    expect(page).to_not have_link('Update Garden Information')
+  end
+  it 'cannot add plants to that garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    
+    visit garden_path(garden)
+    
+    expect(page).to_not have_link('Add a Plant to Your Garden!')
+  end
 end

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -52,6 +52,19 @@ describe 'As a caretaker of a garden' do
     visit edit_plant_path(plant)
     expect(status_code).to eq(404)
   end
+  it 'cannot delete a plant from that garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    plant = create(:plant, garden: garden)
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    
+    visit garden_path(garden)
+    
+    expect(page).to_not have_button('Remove Plant')
+  end
   it 'cannot invite other caretakers to the garden' do
     owner = create(:user)
     caretaker = create(:user, first_name: 'Caretaker')

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -24,6 +24,9 @@ describe 'As a caretaker of a garden' do
     visit garden_path(garden)
     
     expect(page).to_not have_link('Update Garden Information')
+    
+    visit edit_garden_path(garden)
+    expect(status_code).to eq(404)
   end
   it 'cannot add plants to that garden' do
     owner = create(:user)

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -52,4 +52,19 @@ describe 'As a caretaker of a garden' do
     visit edit_plant_path(plant)
     expect(status_code).to eq(404)
   end
+  it 'cannot invite other caretakers to the garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    plant = create(:plant, garden: garden)
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    
+    visit gardens_path
+    
+    within('.caretaking-gardens') do
+      expect(page).to_not have_link('Add Caretaker for this Garden')
+    end
+  end
 end

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -40,4 +40,16 @@ describe 'As a caretaker of a garden' do
     
     expect(page).to_not have_link('Add a Plant to Your Garden!')
   end
+  it 'cannot edit plants for that garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    plant = create(:plant, garden: garden)
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    
+    visit edit_plant_path(plant)
+    expect(status_code).to eq(404)
+  end
 end

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'As a caretaker of a garden' do
+  it 'cannot delete that garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    
+    visit garden_path(garden)
+    
+    expect(page).to_not have_button('Delete Garden')
+  end
+end

--- a/spec/features/caretakers/caretaker_abilities_spec.rb
+++ b/spec/features/caretakers/caretaker_abilities_spec.rb
@@ -80,4 +80,28 @@ describe 'As a caretaker of a garden' do
       expect(page).to_not have_link('Add Caretaker for this Garden')
     end
   end
+  it 'can still do owner things with own garden' do
+    owner = create(:user)
+    caretaker = create(:user, first_name: 'Caretaker')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(caretaker)
+    garden = create(:garden, owners: [owner])
+    plant = create(:plant, garden: garden)
+    create(:user_garden, garden: garden, user: caretaker, relationship_type: 'caretaker')
+    own_garden = create(:garden, owners: [caretaker])
+    own_plant = create(:plant, garden: own_garden)
+    
+    visit garden_path(own_garden)
+    expect(page).to have_button('Delete Garden') 
+    expect(page).to have_link('Update Garden Information')
+    expect(page).to have_link('Add a Plant to Your Garden!')
+    expect(page).to have_button('Remove Plant')
+    
+    visit edit_plant_path(own_plant)
+    expect(status_code).to eq(200)
+    
+    visit gardens_path
+    within('.my-gardens') do
+      expect(page).to have_link('Add Caretaker for this Garden')
+    end
+  end
 end

--- a/spec/features/users/user_can_invite_caretaker_spec.rb
+++ b/spec/features/users/user_can_invite_caretaker_spec.rb
@@ -10,8 +10,8 @@ describe 'as a logged in user' do
     visit gardens_path
 
     within "#garden-#{garden_1.id}" do
-      expect(page).to have_link("Add Caretaker")
-      click_link "Add Caretaker"
+      expect(page).to have_link("Add Caretaker for this Garden")
+      click_link "Add Caretaker for this Garden"
       expect(current_path).to eq(invite_path(garden_1))
     end
   end

--- a/spec/features/users/user_can_update_garden_spec.rb
+++ b/spec/features/users/user_can_update_garden_spec.rb
@@ -42,7 +42,7 @@ describe 'As a logged in user to the site' do
 
       garden_old_name = 'My Garden'
       garden_old_zip = '11111'
-      garden = create(:garden, name: garden_old_name, zip_code: garden_old_zip)
+      garden = create(:garden, name: garden_old_name, zip_code: garden_old_zip, owners: [user])
 
       visit edit_garden_path(garden)
       fill_in :garden_name, with: ''

--- a/spec/models/scheduler_spec.rb
+++ b/spec/models/scheduler_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Scheduler do
+describe Scheduler do 
   it 'exists' do
     expect(Scheduler).to be_a(Object)
   end
@@ -25,15 +25,15 @@ describe Scheduler do
     def a_day_goes_by(plants)
       plants.each do |plant|
         plant.waterings.each do |watering|
-          #similating the passage of time
-          watering.update(water_time: watering.water_time - 1.day)
+          #simulating the passage of time
+          watering.update(water_time: (watering.water_time - 1.day).localtime)
         end
       end
       Scheduler.generate_waterings_for_a_week_from_today
     end
     plant_1 = create(:plant, times_per_week: 7)
     plant_2 = create(:plant, times_per_week: 3)
-    one_week_from_today = Time.now.to_date + 1.week
+    one_week_from_today = (Time.now + 1.week).localtime.to_date
 
     a_day_goes_by([plant_1, plant_2])
     expect(plant_1.reload.waterings.count).to eq(9)


### PR DESCRIPTION
- Adds logic to views so caretakers cannot see buttons to delete or update gardens, or delete or update plants in those gardens
- Adds before_actions to plants and gardens controller so that caretakers cannot access edit, update, or delete paths
- Caretakers can still act as owners on their own gardens
- All tests passing
- Co-authored with @abenetka 
Closes #166 