### PR TITLE
Settings Cosmetics

### DIFF
--- a/app/assets/javascripts/settings.js
+++ b/app/assets/javascripts/settings.js
@@ -4,6 +4,7 @@ $( document ).ready(function() {
       $('#toggleable-phone-field').show();
     } else {
       $('#toggleable-phone-field').hide();
+      $('#user_telephone').val('');
     }
   });
   $('input').click(function() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,7 @@ h1 {
   font-size: 5rem;
   text-align: center;
 }
+
+.error {
+  color: red;
+}

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -6,6 +6,7 @@ class SettingsController < ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update(settings_params)
+      flash[:success] = "Settings Saved."
       redirect_to settings_path
     else
       @errors = @user.errors

--- a/app/views/errors/_validations_failed.html.erb
+++ b/app/views/errors/_validations_failed.html.erb
@@ -1,6 +1,6 @@
 <% if @errors %>
   <ul>
-    <div class="flash">
+    <div class="error">
       <% @errors.full_messages.each do |error| %>
         <li><%= error %></li>
       <% end %>

--- a/spec/features/users/user_receives_notifications_spec.rb
+++ b/spec/features/users/user_receives_notifications_spec.rb
@@ -30,6 +30,7 @@ describe 'notifications' do
       find(:css, "#user_rainy_day_notifications").set(true)
       find(:css, "#user_frost_notifications").set(true)
       click_on("Save")
+      expect(page).to have_content("Settings Saved")
       expect(current_path).to eq(settings_path)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user.reload)
       visit schedules_path
@@ -40,6 +41,7 @@ describe 'notifications' do
       visit settings_path
       find(:css, "#user_receives_texts").set(true)
       click_on("Save")
+      expect(page).to_not have_content("Settings Saved.")
       expect(page).to have_content("Phone number can't be blank if you'd like to receive texts")
       expect(@user.reload.receives_texts).to eq(false)
       fill_in :user_telephone, with: "789"


### PR DESCRIPTION
Adds a success flash message for saving settings.
Makes errors red.
Clears telephone field when 'receive texts' is unchecked.