### PR TITLE
Javascript schedule fixes

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -5,11 +5,10 @@ $( document ).ready(function() {
     let id = $(this).data('id');
     let field = $(`#watering-${id}-completed`)
     let toggledValue = field.val() == "false" ? "true" : "false";
-
     $(iconImage).toggleClass("watered-plant-image")
-    $(field).val(toggledValue)
+    $(field).val(toggledValue) // we still need this given how we're getting toggledValue
     $(`#watering-${id}-name`).toggleClass("watered-plant-name");
-    $(`#update-watering-${id}`).click();
+    updateWatering(id, {completed: toggledValue})
   });
 
   $( ".draggable" ).draggable({
@@ -21,6 +20,7 @@ $( document ).ready(function() {
     tolerance: 'touch',
     drop: function( event, ui ) {
       let draggedFrom = $(ui.draggable[0]).parent();
+      if($(this).attr('id') === draggedFrom.parent().attr('id')) { return true }
       let garden_classes = draggedFrom.attr('class');
       garden_class = garden_classes.split(' ')[0];
       let garden = $(this).find(`.${garden_class}`)
@@ -35,13 +35,23 @@ $( document ).ready(function() {
       }
       ui.draggable.appendTo(garden);
 
-
       $(this).find(".no-waterings").hide();
-      let id = ui.draggable[0].id
-      let field = `#${id}-water-time`
+
+      let id = ui.draggable[0].id.split('-')[1]
       let date = this.parentElement.attributes.name.nodeValue
-      $(field).val(date)
-      $(`#update-${id}`).click();
+      updateWatering(id, {water_time: date})
     }
   });
 });
+
+const updateWatering = (id, attributes) => {
+  let params = {watering: attributes}
+  fetch(`/waterings/${id}?`, {
+    method: 'PATCH',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(params)
+  });
+}

--- a/app/controllers/waterings_controller.rb
+++ b/app/controllers/waterings_controller.rb
@@ -1,4 +1,6 @@
 class WateringsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def update
     watering = Watering.find(params[:id])
     watering.update(watering_update_params)

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -25,7 +25,7 @@ class Day
   end
 
   def css_name
-    @date.strftime('%b%d')
+    @date.strftime('%b%d,%Y')
   end
 
   def css_id

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -25,7 +25,7 @@ class Day
   end
 
   def css_name
-    @date.strftime('%b%d,%Y')
+    @date.strftime('%b%d_%Y')
   end
 
   def css_id

--- a/app/views/schedules/_day_gardens.html.erb
+++ b/app/views/schedules/_day_gardens.html.erb
@@ -1,4 +1,4 @@
-<div class="droppable">
+<div class="droppable" id="<%= day.css_name %>-droppable">
   <% day.gardens.owned.each do |garden| %>
     <%= render partial: "garden", locals: {day: day, garden: garden, type: "owned"} %>
   <% end %>

--- a/spec/features/users/user_generates_schedule_when_adding_a_plant_spec.rb
+++ b/spec/features/users/user_generates_schedule_when_adding_a_plant_spec.rb
@@ -13,40 +13,40 @@ describe 'As a logged in user when I add a plant' do
 
     expect(current_path).to eq(schedules_path)
 
-    within("div[name='#{Time.now.to_date.strftime('%b%d')}']") do
+    within("div[name='#{Time.now.to_date.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
-    within("div[name='#{1.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{1.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name)
     end
 
-    within("div[name='#{2.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{2.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
-    within("div[name='#{3.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{3.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name)
     end
-    within("div[name='#{4.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{4.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
-    within("div[name='#{5.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{5.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name)
     end
-    within("div[name='#{6.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{6.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
-    within("div[name='#{7.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{7.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name)
     end
 
 
-    within("div[name='#{1.days.ago.localtime.strftime('%b%d')}']") do
+    within("div[name='#{1.days.ago.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
-    within("div[name='#{2.days.ago.localtime.strftime('%b%d')}']") do
+    within("div[name='#{2.days.ago.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
-    within("div[name='#{3.days.ago.localtime.strftime('%b%d')}']") do
+    within("div[name='#{3.days.ago.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to_not have_content(plant.name)
     end
   end
@@ -67,28 +67,28 @@ describe 'As a logged in user when I add a plant' do
 
     visit schedules_path
 
-    within("div[name='#{Time.now.to_date.strftime('%b%d')}']") do
+    within("div[name='#{Time.now.to_date.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{1.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{1.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{2.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{2.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{3.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{3.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{4.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{4.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{5.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{5.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{6.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{6.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
-    within("div[name='#{7.days.from_now.localtime.strftime('%b%d')}']") do
+    within("div[name='#{7.days.from_now.localtime.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(plant.name, count: 1)
     end
   end

--- a/spec/features/users/user_sees_schedule_spec.rb
+++ b/spec/features/users/user_sees_schedule_spec.rb
@@ -28,16 +28,16 @@ describe 'user sees schedule' do
     expect(page).to have_content(plant_2.name, count: 1)
     expect(page).to have_content(watering.plant.name, count: 2)
 
-    within("div[name='#{watering.water_time.strftime('%b%d')}']") do
+    within("div[name='#{watering.water_time.strftime('%b%d_%Y')}']") do
       expect(page).to have_content(watering.water_time.strftime('%A'))
       expect(page).to have_content(watering.water_time.strftime('%b. %d'))
-      within("#garden-#{garden_2.id}-#{watering.water_time.strftime('%b%d')}") do
+      within("#garden-#{garden_2.id}-#{watering.water_time.strftime('%b%d_%Y')}") do
         expect(page).to have_link(plant_3.name)
       end
-      within("#garden-#{garden_1.id}-#{watering.water_time.strftime('%b%d')}") do
+      within("#garden-#{garden_1.id}-#{watering.water_time.strftime('%b%d_%Y')}") do
         expect(page).to have_link(plant.name, count: 2)
       end
-      
+
       within "#watering-#{plant.waterings.first.id}-name" do
         click_link(plant.name)
       end
@@ -96,19 +96,19 @@ describe 'user sees schedule' do
     end
     scenario 'when I move a watering it saves and updates the watering date' do
       start_water_time = @watering_1.water_time
-      new_time = (start_water_time + 2.days).strftime('%b%d')
+      new_time = (start_water_time + 2.days).strftime('%b%d_%Y')
 
       set_watering_time(@watering_1, new_time)
       visit schedules_path
 
-      expect(@watering_1.reload.water_time.strftime('%b%d')).to eq(new_time)
+      expect(@watering_1.reload.water_time.strftime('%b%d_%Y')).to eq(new_time)
       within("[name=#{new_time}]") do
         expect(page).to have_content(@watering_1.plant.name)
       end
     end
     scenario 'when there are no waterings on a particular day, I see a message' do
       yesterday = Time.now.to_date - 1.days
-      within("[name=#{yesterday.strftime('%b%d')}]") do
+      within("[name=#{yesterday.strftime('%b%d_%Y')}]") do
         expect(page).to have_content("No waterings scheduled today.")
       end
     end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -9,8 +9,8 @@ describe Day do
     days = Day.generate_days(days_ago: 4, days_from_now: 7)
     expect(days.size).to eq(12)
     expect(days.first).to be_a(Day)
-    expect(days.first.css_name).to eq(4.days.ago.localtime.strftime('%b%d'))
-    expect(days.last.css_name).to eq(7.days.from_now.localtime.strftime('%b%d'))
+    expect(days.first.css_name).to eq(4.days.ago.localtime.strftime('%b%d_%Y'))
+    expect(days.last.css_name).to eq(7.days.from_now.localtime.strftime('%b%d_%Y'))
   end
   it ".small_date" do
     today = Day.new(Time.now)
@@ -18,7 +18,7 @@ describe Day do
   end
   it ".css_name" do
     today = Day.new(Time.now)
-    expect(today.css_name).to eq(Time.now.strftime('%b%d'))
+    expect(today.css_name).to eq(Time.now.strftime('%b%d_%Y'))
   end
   it ".css_id" do
     today = Day.new(Time.now)

--- a/spec/models/rainy_day_spec.rb
+++ b/spec/models/rainy_day_spec.rb
@@ -66,7 +66,7 @@ describe RainyDay do
       garden_1 = create(:garden, owners: [user_2], zip_code: "80000")
       garden_2 = create(:garden, owners: [user_2], zip_code: "80125")
       garden_3 = create(:garden, owners: [user_2], zip_code: "80125")
-      expect(RainyDay.zip_codes).to eq([garden_1.zip_code, garden_2.zip_code])
+      expect(RainyDay.zip_codes.to_set).to eq(Set[garden_1.zip_code, garden_2.zip_code])
     end
   end
   describe 'instance methods' do


### PR DESCRIPTION
- By using fetch instead of clicking on a hidden submit button, this eliminates a problem where multiple updates to a watering weren't being updated in the database. It also gets rid of that weird quirk where an empty file would download in my (and other peoples) browser.

- Changes the css_name method on day poro to involve the year. Without this, if a user were to move a watering from to jan 2020 from dec 2019, it would move to jan 2019.

- There is still un-ideal behavior when there are 'gardens under your care'. The larger containing "gardens under your care div" does not appear or disappear when a single watering is moved to or from a day. I added this as its own card on waffle.