### PR TITLE
Adds favicon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <link rel='stylesheet' href='https://use.fontawesome.com/releases/v5.7.0/css/all.css' integrity='sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ' crossorigin='anonymous'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= javascript_include_tag "https://code.jquery.com/ui/1.12.1/jquery-ui.js", integrity: "sha256-T0Vest3yCU7pafRw9r+settMBX6JkKN06dqBnpQ8d30=", crossorigin: "anonymous" %>
+    <%= favicon_link_tag asset_path('thumb/default.png') %>
   </head>
   <body>
     <div class="container-fluid">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41645771/54061798-b30c5680-41bf-11e9-85a2-e30d0d481495.png)

I'm curious if there would be any optimization effect of actually making a 32x32 image in app/assets. My somewhat squishy understanding is that the magic of the rails asset pipeline is creating this tiny image for us, and it's already optimized: 
https://apidock.com/rails/ActionView/Helpers/AssetTagHelper/favicon_link_tag