### PR TITLE
Limit missed waterings#211

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
 
   def self.with_missed_waterings
     User.includes(gardens: {plants: :waterings})
-        .where("waterings.water_time < ?", Date.today)
+        .where(waterings: {water_time: (Date.today - 4.days)...Date.today} )
         .joins(gardens: {plants: :waterings})
   end
 

--- a/spec/features/users/user_receives_notifications_spec.rb
+++ b/spec/features/users/user_receives_notifications_spec.rb
@@ -72,6 +72,11 @@ describe 'notifications' do
       expect(current_path).to eq(schedules_path)
     end
     it 'sends only to the right users' do
+      def create_past_watering(user, days)
+        garden = create(:garden, users: [user])
+        plant = create(:plant, garden: garden)
+        create(:watering, plant: plant, water_time: days.days.ago)
+      end
       user_1 = create(:user)
       user_2 = create(:user)
       user_3 = create(:user, receives_emails: false)
@@ -79,11 +84,11 @@ describe 'notifications' do
 
       users = [user_1, user_2, user_3, user_4]
       users.each do |user|
-        garden = create(:garden, users: [user])
-        plant = create(:plant, garden: garden)
-        create(:watering, plant: plant, water_time: 3.days.ago)
+        create_past_watering(user, 4)
       end
       user_5 = create(:user)
+      user_6 = create(:user)
+      create_past_watering(user_6, 5)
 
       mock_mailer = spy('UnwateredNotifierMailer')
       stub_const('UnwateredNotifierMailer', mock_mailer)
@@ -94,6 +99,7 @@ describe 'notifications' do
       expect(mock_mailer).to_not have_received(:inform).with(user_3)
       expect(mock_mailer).to_not have_received(:inform).with(user_4)
       expect(mock_mailer).to_not have_received(:inform).with(user_5)
+      expect(mock_mailer).to_not have_received(:inform).with(user_6)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe User, type: :model do
       plant_2 = create(:plant, garden: garden_2)
 
       watering_1 = create(:watering, water_time: Date.today - 1.days, plant: plant_1)
-      watering_2 = create(:watering, water_time: 3.days.ago.to_date, plant: plant_2)
-      watering_3 = create(:watering, water_time: 4.days.ago.to_date, plant: plant_2)
+      watering_2 = create(:watering, water_time: Date.today - 3.days, plant: plant_2)
+      watering_3 = create(:watering, water_time: Date.today - 4.days, plant: plant_2)
+      #This last watering is too far in the past to be concerned about
+      watering_4 = create(:watering, water_time: Date.today - 5.days, plant: plant_2)
 
       result = User.with_missed_waterings
 


### PR DESCRIPTION
Missed waterings now only go as far back as the schedule page. Users will not be notified about waterings they missed a week or year ago (and have no means of updating). Adds to unit and feature test.

closes #211 
