### PR TITLE
Collapse schedule

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -49,7 +49,7 @@ $( document ).ready(function() {
     let content = $(this.lastElementChild);
     let clicked = event.target.className;
     if(clicked.includes("collapsible") || clicked === "weekday" || clicked === "date" || clicked.includes("fas")) {
-      content.toggle();
+      content.toggleClass("expanded");
     };
   });
 });

--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -44,4 +44,12 @@ $( document ).ready(function() {
       $(`#update-${id}`).click();
     }
   });
+  
+  $(".collapsible").click(event, function() {
+    let content = $(this.lastElementChild);
+    let clicked = event.target.className;
+    if(clicked.includes("collapsible") || clicked === "weekday" || clicked === "date" || clicked.includes("fas")) {
+      content.toggle();
+    };
+  });
 });

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -65,6 +65,7 @@ h2 {
 
 .watering {
   padding: 10px;
+  padding-top: 0;
 }
 .card {
   display: flex;

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -59,7 +59,7 @@ hr {
   padding: 10px;
 }
 
-.droppable {
+.flex-wrap {
   display: flex;
 }
 

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -1,6 +1,11 @@
-
+hr {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
 
 #today {
+  padding-top: 12px;
+  padding-bottom: 12px;
   background-color: white;
 }
 
@@ -11,18 +16,22 @@
     opacity: 1;
   }
 }
-.future-day {
-  background-color: #C2D0CB;
-}
+
 .row {
   border-radius: 25px;
   padding: 30px;
   display: block;
 }
 
+.future-day {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  background-color: #C2D0CB;
+}
+
 .watering-container {
   margin: 3rem;
-
+  margin-top: 1rem;
 }
 
 .watered-plant-name {
@@ -54,6 +63,27 @@
   display: flex;
 }
 
+.collapsible {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-radius: 10px;
+  
+  .droppable {
+    display: none;
+  }
+}
+
+.weekday, 
+.date {
+  display: inline;
+  padding-left: 5px;
+}
+
+.date {
+  padding-bottom: 3px;
+  font-size: 1.25rem;
+}
+
 .caretaking {
   background-color: rgba(180,200,200,0.8)
 }
@@ -72,6 +102,7 @@
 .garden-day-header {
   padding-left: 20px;
   padding-top: 10px;
+  margin-bottom: 0;
   text-transform: uppercase;
   font-size: smaller;
 }

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -73,6 +73,10 @@ hr {
   }
 }
 
+.expanded {
+  display: flex !important;
+}
+
 .weekday, 
 .date {
   display: inline;

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -19,7 +19,7 @@ class Day
 
   def css_classes
     class_names = 'row'
-    class_names += ' past-day' if (@date < Date.today)
+    class_names += ' past-day collapsible' if (@date < Date.today)
     class_names += ' future-day' if (@date > Date.today)
     class_names
   end

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -6,7 +6,7 @@
     <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
       <div class="btn-group mr-2" role="group" aria-label="First group">
         <button type="button" class="btn btn-secondary">
-          <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn" %>
+          <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
         </button>
         <button type="button" class="btn btn-secondary">
           <%= button_to 'Create New Garden', new_garden_path, method: :get, class: "btn" %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="btn-group mr-2" role="group" aria-label="Fourth group">
         <button type="button" class="btn btn-secondary" id="schedule-button">
-          <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn"  %>
+          <%= link_to 'View Watering Schedule', schedules_path, class: "btn"  %>
         </button>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
           <div class="navbar-nav">
             <%= link_to 'Dashboard', dashboard_path, class: "nav-item nav-link"  %>
             <%= link_to 'My Gardens', gardens_path, class: "nav-item nav-link"  %>
-            <%= link_to 'Schedule', schedules_path(anchor: "today"), class: "nav-item nav-link" %>
+            <%= link_to 'Schedule', schedules_path, class: "nav-item nav-link" %>
             <%= link_to 'Sign Out', signout_path, class: "nav-item nav-link"%>
             <%= link_to "Settings", settings_path, class: "nav-item nav-link" %>
           </div>

--- a/app/views/schedules/_day_gardens.html.erb
+++ b/app/views/schedules/_day_gardens.html.erb
@@ -1,4 +1,4 @@
-<div class="droppable">
+<div class="droppable flex-wrap">
   <% day.gardens.owned.each do |garden| %>
     <%= render partial: "garden", locals: {day: day, garden: garden, type: "owned"} %>
   <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -2,8 +2,11 @@
 <div class="watering-container">
   <% @days.each do |day| %>
     <div class="<%= day.css_classes %>" name='<%= day.css_name %>'  id='<%= day.css_id %>'>
-      <h3><%= day.day_of_week_name %></h3>
-      <h6><%= day.small_date %></h6>
+      <h3 class="weekday"><%= day.day_of_week_name %></h3>
+      <h6 class="date"><%= day.small_date %></h6>
+      <% if day.css_classes.include?('collapsible') %>
+        <i class="fas fa-caret-down"></i>
+      <% end %>
      <%= render partial: "day_gardens", locals: {day: day} %>
     </div>
   <hr>

--- a/app/views/users/_today_thirsty_plants.html.erb
+++ b/app/views/users/_today_thirsty_plants.html.erb
@@ -1,5 +1,5 @@
 <div id="todays-plants" class="today-card">
-  <h3><%= link_to "Today's Thirsty Plants", schedules_path(anchor: "today") %></h3>
+  <h3><%= link_to "Today's Thirsty Plants", schedules_path %></h3>
   <div class=todays-gardens-container>
     <% if @facade.today.gardens.count == 0 %>
       <h4>No Thirsty Plants Today!</h4>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
       <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
         <div class="btn-group mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-secondary">
-            <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn" %>
+            <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
           </button>
         </div>
         <div class="btn-group mr-2" role="group" aria-label="Third group">
@@ -74,7 +74,7 @@
       <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
         <div class="btn-group mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-secondary">
-            <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn" %>
+            <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
           </button>
         </div>
         <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,8 +40,5 @@ module ThirstyPlants
     }
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
-    
-    config.time_zone = "Mountain Time (US & Canada)"
-    config.active_record.default_timezone = :local
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,8 @@ module ThirstyPlants
     }
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
+    
+    config.time_zone = "Mountain Time (US & Canada)"
+    config.active_record.default_timezone = :local
   end
 end

--- a/spec/features/users/user_receives_notifications_spec.rb
+++ b/spec/features/users/user_receives_notifications_spec.rb
@@ -75,7 +75,7 @@ describe 'notifications' do
       def create_past_watering(user, days)
         garden = create(:garden, users: [user])
         plant = create(:plant, garden: garden)
-        create(:watering, plant: plant, water_time: days.days.ago)
+        create(:watering, plant: plant, water_time: Date.today - days.days)
       end
       user_1 = create(:user)
       user_2 = create(:user)

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -31,7 +31,7 @@ describe Day do
     yesterday = Day.new(Date.today - 1.days)
     tomorrow = Day.new(Date.today + 1.days)
     expect(today.css_classes).to eq('row')
-    expect(yesterday.css_classes).to eq('row past-day')
+    expect(yesterday.css_classes).to eq('row past-day collapsible')
     expect(tomorrow.css_classes).to eq('row future-day')
   end
 


### PR DESCRIPTION
Makes the schedule a bit easier to see by compressing some of the styling and making past days collapsed:
- Adds `collapsible` class to past days
- Adds collapsible functionality that toggles the display between `none` and `flex` so that it expands/collapses
- Adds little down-carat icon to indicate that the past days are collapsed
- Removes `anchor: today` from all links to Schedule since now it's much easier to see past days and today all in one screen
- Generally tightens up styling on the schedule so there's less space between things
- Updates one of the tests to use local time (was failing after 6pm which is the new 5pm as of last night)
- Adds `flex-wrap` bootstrap class which makes it so that the gardens on the schedule wrap when on mobile, rather than forcing a row (which looks awkward and impacts usability). 

All tests passing