### PR TITLE
Adds time zone config to application.rb file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
 - gem install bundler
 before_script:
 - bundle exec rake db:{drop,create,migrate,seed}
+- echo 'Mountain Time (US & Canada)' | sudo tee /etc/timezone
+- sudo dpkg-reconfigure --frontend noninteractive tzdata
 script:
 - bundle exec rspec
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_install:
 - gem install bundler
 before_script:
 - bundle exec rake db:{drop,create,migrate,seed}
-- echo 'Mountain Time (US & Canada)' | sudo tee /etc/timezone
-- sudo dpkg-reconfigure --frontend noninteractive tzdata
+- export TZ='America/Denver'
 script:
 - bundle exec rspec
 env:

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,8 @@ module ThirstyPlants
     }
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
+    
+    config.time_zone = "Mountain Time (US & Canada)"
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
Adds time zone to `application.rb` in an attempt to force Heroku to Mountain Time. Note - this means it is Mountain Time for ALL users. Not really ideal, but good enough for now since the majority of our users are likely to be in the USA.
All tests passing locally.