### PR TITLE
Choose gardens

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -57,5 +57,6 @@ $( document ).ready(function() {
     let garden = event.target.id;
     let gardens = $(`.${garden}`);
     gardens.toggle();
+    $(this).toggleClass("unselected-garden");
   });
 });

--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -49,7 +49,7 @@ $( document ).ready(function() {
     let content = $(this.lastElementChild);
     let clicked = event.target.className;
     if(clicked.includes("collapsible") || clicked === "weekday" || clicked === "date" || clicked.includes("fas")) {
-      content.toggle();
+      content.toggleClass("expanded");
     };
   });
 });

--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -52,4 +52,10 @@ $( document ).ready(function() {
       content.toggleClass("expanded");
     };
   });
+  
+  $(".select-garden").click(event, function() {
+    let garden = event.target.id;
+    let gardens = $(`.${garden}`);
+    gardens.toggle();
+  });
 });

--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -44,4 +44,12 @@ $( document ).ready(function() {
       $(`#update-${id}`).click();
     }
   });
+  
+  $(".collapsible").click(event, function() {
+    let content = $(this.lastElementChild);
+    let clicked = event.target.className;
+    if(clicked.includes("collapsible") || clicked === "weekday" || clicked === "date" || clicked.includes("fas")) {
+      content.toggle();
+    };
+  });
 });

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -65,6 +65,7 @@ h2 {
 
 .watering {
   padding: 10px;
+  padding-top: 0;
 }
 .card {
   display: flex;

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -130,13 +130,15 @@ hr {
   font-weight: bold;
   text-transform: uppercase;
     &:hover {
-      background-color: rgba(209, 193, 189, 0.8);
+      background-color: rgba(240, 154, 60, 1);
+      -webkit-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
     }
 }
 
 .unselected-garden {
   background-color: rgba(209, 193, 189, 0.8);
     &:hover {
-      background-color: rgba(240, 154, 60, 0.8);
+      background-color: rgba(209, 193, 189, 1);
     }
 }

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -116,8 +116,6 @@ hr {
   padding-bottom: 12px;
   background-color: #C2D0CB;
   border-radius: 0;
-  border-top: 2px solid rgba(35, 87, 77, 1);
-  border-bottom: 2px solid rgba(35, 87, 77, 1);
   h3 {
     margin-bottom: 10px;
     margin-right: 20px;

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -59,7 +59,7 @@ hr {
   padding: 10px;
 }
 
-.droppable {
+.flex-wrap {
   display: flex;
 }
 

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -114,15 +114,31 @@ hr {
 .garden-selector {
   padding-top: 12px;
   padding-bottom: 12px;
-  background-color: white;
+  background-color: #C2D0CB;
   border-radius: 0;
+  border-top: 2px solid rgba(35, 87, 77, 1);
+  border-bottom: 2px solid rgba(35, 87, 77, 1);
+  h3 {
+    margin-bottom: 10px;
+    margin-right: 20px;
+  }
 }
 
 .select-garden {
   margin: 0 0.5rem 0 0.5rem;
   padding: 12px;
-  background-color: rgba(209, 193, 189, 0.8);
+  background-color: rgba(240, 154, 60, 0.8);
   border-radius: 10px;
   font-weight: bold;
   text-transform: uppercase;
+    &:hover {
+      background-color: rgba(209, 193, 189, 0.8);
+    }
+}
+
+.unselected-garden {
+  background-color: rgba(209, 193, 189, 0.8);
+    &:hover {
+      background-color: rgba(240, 154, 60, 0.8);
+    }
 }

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -1,6 +1,11 @@
-
+hr {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
 
 #today {
+  padding-top: 12px;
+  padding-bottom: 12px;
   background-color: white;
 }
 
@@ -11,18 +16,22 @@
     opacity: 1;
   }
 }
-.future-day {
-  background-color: #C2D0CB;
-}
+
 .row {
   border-radius: 25px;
   padding: 30px;
   display: block;
 }
 
+.future-day {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  background-color: #C2D0CB;
+}
+
 .watering-container {
   margin: 3rem;
-
+  margin-top: 1rem;
 }
 
 .watered-plant-name {
@@ -54,6 +63,27 @@
   display: flex;
 }
 
+.collapsible {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-radius: 10px;
+  
+  .droppable {
+    display: none;
+  }
+}
+
+.weekday, 
+.date {
+  display: inline;
+  padding-left: 5px;
+}
+
+.date {
+  padding-bottom: 3px;
+  font-size: 1.25rem;
+}
+
 .caretaking {
   background-color: rgba(180,200,200,0.8)
 }
@@ -72,6 +102,7 @@
 .garden-day-header {
   padding-left: 20px;
   padding-top: 10px;
+  margin-bottom: 0;
   text-transform: uppercase;
   font-size: smaller;
 }

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -73,6 +73,10 @@ hr {
   }
 }
 
+.expanded {
+  display: flex !important;
+}
+
 .weekday, 
 .date {
   display: inline;

--- a/app/assets/stylesheets/schedule.scss.erb
+++ b/app/assets/stylesheets/schedule.scss.erb
@@ -110,3 +110,19 @@ hr {
   text-transform: uppercase;
   font-size: smaller;
 }
+
+.garden-selector {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  background-color: white;
+  border-radius: 0;
+}
+
+.select-garden {
+  margin: 0 0.5rem 0 0.5rem;
+  padding: 12px;
+  background-color: rgba(209, 193, 189, 0.8);
+  border-radius: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+}

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -19,7 +19,7 @@ class Day
 
   def css_classes
     class_names = 'row'
-    class_names += ' past-day' if (@date < Date.today)
+    class_names += ' past-day collapsible' if (@date < Date.today)
     class_names += ' future-day' if (@date > Date.today)
     class_names
   end

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -6,7 +6,7 @@
     <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
       <div class="btn-group mr-2" role="group" aria-label="First group">
         <button type="button" class="btn btn-secondary">
-          <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn" %>
+          <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
         </button>
         <button type="button" class="btn btn-secondary">
           <%= button_to 'Create New Garden', new_garden_path, method: :get, class: "btn" %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="btn-group mr-2" role="group" aria-label="Fourth group">
         <button type="button" class="btn btn-secondary" id="schedule-button">
-          <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn"  %>
+          <%= link_to 'View Watering Schedule', schedules_path, class: "btn"  %>
         </button>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
           <div class="navbar-nav">
             <%= link_to 'Dashboard', dashboard_path, class: "nav-item nav-link"  %>
             <%= link_to 'My Gardens', gardens_path, class: "nav-item nav-link"  %>
-            <%= link_to 'Schedule', schedules_path(anchor: "today"), class: "nav-item nav-link" %>
+            <%= link_to 'Schedule', schedules_path, class: "nav-item nav-link" %>
             <%= link_to 'Sign Out', signout_path, class: "nav-item nav-link"%>
             <%= link_to "Settings", settings_path, class: "nav-item nav-link" %>
           </div>

--- a/app/views/schedules/_day_gardens.html.erb
+++ b/app/views/schedules/_day_gardens.html.erb
@@ -1,4 +1,4 @@
-<div class="droppable">
+<div class="droppable flex-wrap">
   <% day.gardens.owned.each do |garden| %>
     <%= render partial: "garden", locals: {day: day, garden: garden, type: "owned"} %>
   <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Watering Schedule</h1>
-<div class="row flex-wrap garden-selector">
+<div class="row flex-wrap sticky-top garden-selector">
   <h3>Gardens to Display </h3>
   <% current_user.gardens.each do |garden| %>
     <div id="garden-<%= garden.id %>" class="select-garden">

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Watering Schedule</h1>
 <div class="row flex-wrap garden-selector">
-  <h3>Gardens to Display</h3>
+  <h3>Gardens to Display </h3>
   <% current_user.gardens.each do |garden| %>
     <div id="garden-<%= garden.id %>" class="select-garden">
       <%= garden.name %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,4 +1,12 @@
 <h1>Watering Schedule</h1>
+<div class="row flex-wrap garden-selector">
+  <h3>Gardens to Display</h3>
+  <% current_user.gardens.each do |garden| %>
+    <div id="garden-<%= garden.id %>" class="select-garden">
+      <%= garden.name %>
+    </div>
+  <% end %>
+</div>
 <div class="watering-container">
   <% @days.each do |day| %>
     <div class="<%= day.css_classes %>" name='<%= day.css_name %>'  id='<%= day.css_id %>'>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -2,8 +2,11 @@
 <div class="watering-container">
   <% @days.each do |day| %>
     <div class="<%= day.css_classes %>" name='<%= day.css_name %>'  id='<%= day.css_id %>'>
-      <h3><%= day.day_of_week_name %></h3>
-      <h6><%= day.small_date %></h6>
+      <h3 class="weekday"><%= day.day_of_week_name %></h3>
+      <h6 class="date"><%= day.small_date %></h6>
+      <% if day.css_classes.include?('collapsible') %>
+        <i class="fas fa-caret-down"></i>
+      <% end %>
      <%= render partial: "day_gardens", locals: {day: day} %>
     </div>
   <hr>

--- a/app/views/users/_today_thirsty_plants.html.erb
+++ b/app/views/users/_today_thirsty_plants.html.erb
@@ -1,5 +1,5 @@
 <div id="todays-plants" class="today-card">
-  <h3><%= link_to "Today's Thirsty Plants", schedules_path(anchor: "today") %></h3>
+  <h3><%= link_to "Today's Thirsty Plants", schedules_path %></h3>
   <div class=todays-gardens-container>
     <% if @facade.today.gardens.count == 0 %>
       <h4>No Thirsty Plants Today!</h4>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
       <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
         <div class="btn-group mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-secondary">
-            <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn" %>
+            <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
           </button>
         </div>
         <div class="btn-group mr-2" role="group" aria-label="Third group">
@@ -74,7 +74,7 @@
       <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
         <div class="btn-group mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-secondary">
-            <%= link_to 'View Watering Schedule', schedules_path(anchor: "today"), class: "btn" %>
+            <%= link_to 'View Watering Schedule', schedules_path, class: "btn" %>
           </button>
         </div>
         <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,8 +40,5 @@ module ThirstyPlants
     }
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
-    
-    config.time_zone = "Mountain Time (US & Canada)"
-    config.active_record.default_timezone = :local
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,8 @@ module ThirstyPlants
     }
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
+    
+    config.time_zone = "Mountain Time (US & Canada)"
+    config.active_record.default_timezone = :local
   end
 end

--- a/spec/features/users/user_receives_notifications_spec.rb
+++ b/spec/features/users/user_receives_notifications_spec.rb
@@ -75,7 +75,7 @@ describe 'notifications' do
       def create_past_watering(user, days)
         garden = create(:garden, users: [user])
         plant = create(:plant, garden: garden)
-        create(:watering, plant: plant, water_time: days.days.ago)
+        create(:watering, plant: plant, water_time: Date.today - days.days)
       end
       user_1 = create(:user)
       user_2 = create(:user)

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -31,7 +31,7 @@ describe Day do
     yesterday = Day.new(Date.today - 1.days)
     tomorrow = Day.new(Date.today + 1.days)
     expect(today.css_classes).to eq('row')
-    expect(yesterday.css_classes).to eq('row past-day')
+    expect(yesterday.css_classes).to eq('row past-day collapsible')
     expect(tomorrow.css_classes).to eq('row future-day')
   end
 


### PR DESCRIPTION
Adds ability to choose what gardens you want to show on the watering schedule
- Adds new "Gardens to Display" sticky section to top of schedule
- Adds JS so that when one of the gardens there is clicked, it shows or hides the equivalent gardens in the schedule
- Doesn't currently differentiate between own and caretaking gardens, could implement in the future
- All tests passing

![image](https://user-images.githubusercontent.com/6686861/54098539-a2541000-437a-11e9-8831-6012c2dd4496.png)
